### PR TITLE
Add possibility to apply a filter to LogCaptor's logs

### DIFF
--- a/src/main/java/nl/altindag/log/LogCaptor.java
+++ b/src/main/java/nl/altindag/log/LogCaptor.java
@@ -20,6 +20,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.ThrowableProxy;
+import ch.qos.logback.core.filter.Filter;
 import ch.qos.logback.core.read.ListAppender;
 import nl.altindag.log.model.LogEvent;
 import org.slf4j.LoggerFactory;
@@ -158,6 +159,11 @@ public final class LogCaptor {
                 .orElse(null);
 
         return new LogEvent(message, formattedMessage, level, timeStamp, arguments, throwable);
+    }
+
+    public void addFilter(Filter<ILoggingEvent> filter) {
+        this.listAppender.addFilter(filter);
+        filter.start();
     }
 
     /**

--- a/src/test/java/nl/altindag/log/LogCaptorShould.java
+++ b/src/test/java/nl/altindag/log/LogCaptorShould.java
@@ -16,6 +16,9 @@
 
 package nl.altindag.log;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.filter.LevelFilter;
+import ch.qos.logback.core.spi.FilterReply;
 import nl.altindag.log.model.LogEvent;
 import nl.altindag.log.service.LogMessage;
 import nl.altindag.log.service.Service;
@@ -323,6 +326,25 @@ class LogCaptorShould {
                             "See here for an example configurations: https://github.com/Hakky54/log-captor#using-log-captor-alongside-with-other-logging-libraries"
                     );
         }
+    }
+
+    @Test
+    void filterInfoMessages() {
+        LevelFilter levelFilter = new LevelFilter();
+        levelFilter.setOnMismatch(FilterReply.DENY);
+        levelFilter.setLevel(Level.INFO);
+
+        logCaptor = LogCaptor.forClass(FooService.class);
+        logCaptor.addFilter(levelFilter);
+        logCaptor.setLogLevelToTrace();
+
+        Service service = new FooService();
+        service.sayHello();
+
+        assertThat(logCaptor.getLogEvents())
+                .extracting(LogEvent::getLevel)
+                .map(Level::toLevel)
+                .allMatch(Level.INFO::equals, "INFO");
     }
 
     private static void assertLogMessages(LogCaptor logCaptor, LogMessage... logMessages) {


### PR DESCRIPTION
Hi! I have found your library very useful. 
I'm working on a project, where logs have business meaning (some of them are even persisted in database, some of them act like alerts for monitoring team and etc ...).
We created our own appenders  and applied some custom filters to filter out business logs from regular application logs.

I think we could use your library for testing purposes, however it would be nice, if the library would support logs filtering.

For ex. we want to capture all the logs related to user creation and don't gather unwanted logs. We would do something like this (assuming we don't know exact class for this log event):
```java
public class UserCreationFilter extends Filter<ILoggingEvent> {

    @Override
    public FilterReply decide(ILoggingEvent event) {
        if (event.getMarker() == USER_ACTIONS && isNotEmpty(event.getArgumentArray())) {
            return event.getArgumentArray()[0] == CREATED ? FilterReply.ACCEPT : FilterReply.DENY;
        }
        
        return FilterReply.DENY;
    }
}
```
```java
LogCaptor captor = LogCaptor.forName("org.organization");
captor.setFilter(new UserCreationFilter()); 
```

Without filter it will capture the whole application logs, but with the filter it will reduce the amount of captured logs.