### PR TITLE
Added information about capturing static inner classes, fixed javadoc warnings

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -426,6 +426,12 @@ configurations {
 }
 ```
 
+## Capturing logs of static inner classes
+LogCaptor successfully catches logs of static inner classes with `LogCaptor.forClass(StaticInnerClass.class)` construction 
+when SLF4J or JUL is used. This doesn't apply to Log4j2 because by default it uses `Class.getCanonicalName()` 
+inside instead of `Class.getName()`. You should use `LogCaptor.forName(StaticInnerClass.class.getCanonicalName())` for successful 
+test execution with Log4j2.
+
 # Contributing
 
 There are plenty of ways to contribute to this project:

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${version.junit}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${version.assertj}</version>

--- a/src/main/java/nl/altindag/log/LogCaptor.java
+++ b/src/main/java/nl/altindag/log/LogCaptor.java
@@ -70,6 +70,8 @@ public final class LogCaptor implements AutoCloseable {
 
     /**
      * Captures all log messages
+     *
+     * @return LogCaptor instance for the root logger
      */
     public static LogCaptor forRoot() {
         return new LogCaptor(ROOT_LOGGER_NAME);
@@ -77,13 +79,19 @@ public final class LogCaptor implements AutoCloseable {
 
     /**
      * Captures log messages for the provided class
+     *
+     * @param clazz Class for capturing
+     * @return LogCaptor instance for the provided class
      */
-    public static <T> LogCaptor forClass(Class<T> clazz) {
+    public static LogCaptor forClass(Class<?> clazz) {
         return new LogCaptor(clazz.getName());
     }
 
     /**
      * Captures log messages for the provided logger name
+     *
+     * @param name Logger name for capturing
+     * @return LogCaptor instance for the provided logger name
      */
     public static LogCaptor forName(String name) {
         return new LogCaptor(name);

--- a/src/test/java/nl/altindag/log/LogCaptorShould.java
+++ b/src/test/java/nl/altindag/log/LogCaptorShould.java
@@ -35,11 +35,15 @@ import nl.altindag.log.service.lombok.ServiceWithLombokAndSlf4j;
 import nl.altindag.log.service.slfj4.ServiceWithSlf4j;
 import nl.altindag.log.service.slfj4.ServiceWithSlf4jAndCustomException;
 import nl.altindag.log.service.slfj4.ServiceWithSlf4jAndMdcHeaders;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.slf4j.Log4jLogger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockedStatic;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -52,10 +56,12 @@ import java.util.Optional;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -411,6 +417,70 @@ class LogCaptorShould {
         }
 
         assertThat(fetchAppenders(logger)).isEmpty();
+    }
+
+    @ParameterizedTest(name = "[{index}] Capture no log events with Class.getCanonicalName()")
+    @MethodSource("fetchArgumentsForNoLogEvents")
+    void captureNoLogEventsFromStaticInnerClasses(Runnable staticInnerClassMethod) {
+        try (LogCaptor logCaptor = LogCaptor.forClass(StaticInnerTestClass.class)) {
+            staticInnerClassMethod.run();
+            assertThat(logCaptor.getLogEvents()).isEmpty();
+        }
+    }
+
+    @ParameterizedTest(name = "[{index}] Capture log events with Class.getName()")
+    @MethodSource("fetchArgumentsForLogEvents")
+    void captureLogEventsFromStaticInnerClasses(Runnable staticInnerClassMethod, String expectedMessage) {
+        try (LogCaptor logCaptor = LogCaptor.forClass(StaticInnerTestClass.class)) {
+            staticInnerClassMethod.run();
+
+            assertThat(logCaptor.getInfoLogs())
+                    .hasSize(1)
+                    .first()
+                    .isEqualTo(expectedMessage);
+        }
+    }
+
+    private static class StaticInnerTestClass {
+        static void call(org.apache.logging.log4j.Logger logger) {
+            logger.info("Test message from Log4j2");
+        }
+
+        static void call(org.slf4j.Logger logger) {
+            logger.info("Test message from SLF4J");
+        }
+
+        static void call(java.util.logging.Logger logger) {
+            logger.info("Test message from JUL");
+        }
+    }
+
+    // MethodSource for captureNoLogEventsFromStaticInnerClasses
+    @SuppressWarnings("unused")
+    private static Stream<Arguments> fetchArgumentsForNoLogEvents() {
+        String canonicalName = StaticInnerTestClass.class.getCanonicalName();
+
+        Runnable log4j2 = () -> StaticInnerTestClass.call(LogManager.getLogger(StaticInnerTestClass.class));
+        Runnable slf4j = () -> StaticInnerTestClass.call(LoggerFactory.getLogger(canonicalName));
+        Runnable jul = () -> StaticInnerTestClass.call(java.util.logging.Logger.getLogger(canonicalName));
+
+        return Stream.of(arguments(log4j2), arguments(slf4j), arguments(jul));
+    }
+
+    // MethodSource for captureLogEventsFromStaticInnerClasses
+    @SuppressWarnings("unused")
+    private static Stream<Arguments> fetchArgumentsForLogEvents() {
+        String name = StaticInnerTestClass.class.getName();
+
+        Runnable log4j2 = () -> StaticInnerTestClass.call(LogManager.getLogger(name));
+        Runnable slf4j = () -> StaticInnerTestClass.call(LoggerFactory.getLogger(StaticInnerTestClass.class));
+        Runnable jul = () -> StaticInnerTestClass.call(java.util.logging.Logger.getLogger(name));
+
+        return Stream.of(
+                arguments(log4j2, "Test message from Log4j2"),
+                arguments(slf4j, "Test message from SLF4J"),
+                arguments(jul, "Test message from JUL")
+        );
     }
 
     private static void assertListAppender(Logger logger) {


### PR DESCRIPTION
Hello!

Originally I've found this issue in Spring Boot integration tests
How to reproduce: create some static inner class and try to capture its logs - it will write logs as expected but nothing will be captured
It happens because `Class.getName()` on static inner class will return something like org.example.untitled.**Main$Inner** but for correct capturing we need org.example.untitled.**Main.Inner** which can be returned by `Class.getCanonicalName()` (also may return **null** in some cases so I used `Optional`)

Also fixed some javadoc warnings from build log

Please review and give me some feedback)
Thx