### PR TITLE
#21 Use synchronizedList to capture log events

### DIFF
--- a/src/main/java/nl/altindag/log/LogCaptor.java
+++ b/src/main/java/nl/altindag/log/LogCaptor.java
@@ -147,7 +147,7 @@ public final class LogCaptor implements AutoCloseable {
         synchronized (eventList) {
             return eventList.stream()
                     .map(toLogEvent())
-                    .collect(toList());
+                    .collect(collectingAndThen(toList(), Collections::unmodifiableList));
         }
     }
 


### PR DESCRIPTION
This makes LogCaptor suitable for using in multi-threaded 'integration' tests