### PR TITLE
Add equals and hashcode

### DIFF
--- a/src/main/java/nl/altindag/log/mapper/LogEventMapper.java
+++ b/src/main/java/nl/altindag/log/mapper/LogEventMapper.java
@@ -71,7 +71,7 @@ public final class LogEventMapper implements Function<ILoggingEvent, LogEvent> {
         List<LogMarker> logMarkers = Collections.emptyList();
         if (iLoggingEvent.getMarkerList() != null) {
             logMarkers = iLoggingEvent.getMarkerList().stream()
-                    .map(MarkerMapper.getInstance())
+                    .map(LogMarkerMapper.getInstance())
                     .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
         }
 

--- a/src/main/java/nl/altindag/log/mapper/LogMarkerMapper.java
+++ b/src/main/java/nl/altindag/log/mapper/LogMarkerMapper.java
@@ -30,11 +30,11 @@ import java.util.function.Function;
  *
  * @author Hakan Altindag
  */
-public final class MarkerMapper implements Function<Marker, LogMarker> {
+public final class LogMarkerMapper implements Function<Marker, LogMarker> {
 
-    private static final MarkerMapper INSTANCE = new MarkerMapper();
+    private static final LogMarkerMapper INSTANCE = new LogMarkerMapper();
 
-    private MarkerMapper() {}
+    private LogMarkerMapper() {}
 
     @Override
     public LogMarker apply(Marker marker) {
@@ -52,7 +52,7 @@ public final class MarkerMapper implements Function<Marker, LogMarker> {
         return new LogMarker(name, Collections.unmodifiableList(innerLogMarkers));
     }
 
-    public static MarkerMapper getInstance() {
+    public static LogMarkerMapper getInstance() {
         return INSTANCE;
     }
 }

--- a/src/main/java/nl/altindag/log/model/LogEvent.java
+++ b/src/main/java/nl/altindag/log/model/LogEvent.java
@@ -124,4 +124,26 @@ public final class LogEvent {
                 '}';
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof LogEvent)) return false;
+        LogEvent logEvent = (LogEvent) o;
+        return Objects.equals(message, logEvent.message)
+                && Objects.equals(formattedMessage, logEvent.formattedMessage)
+                && Objects.equals(level, logEvent.level)
+                && Objects.equals(loggerName, logEvent.loggerName)
+                && Objects.equals(threadName, logEvent.threadName)
+                && Objects.equals(timeStamp, logEvent.timeStamp)
+                && Objects.equals(arguments, logEvent.arguments)
+                && Objects.equals(throwable, logEvent.throwable)
+                && Objects.equals(diagnosticContext, logEvent.diagnosticContext)
+                && Objects.equals(keyValuePairs, logEvent.keyValuePairs)
+                && Objects.equals(logMarkers, logEvent.logMarkers);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message, formattedMessage, level, loggerName, threadName,
+                timeStamp, arguments, throwable, diagnosticContext, keyValuePairs, logMarkers);
+    }
 }

--- a/src/main/java/nl/altindag/log/model/LogMarker.java
+++ b/src/main/java/nl/altindag/log/model/LogMarker.java
@@ -16,6 +16,7 @@
 package nl.altindag.log.model;
 
 import java.util.List;
+import java.util.Objects;
 
 public final class LogMarker {
 
@@ -41,5 +42,18 @@ public final class LogMarker {
                 "name='" + name + '\'' +
                 ", references=" + references +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof LogMarker)) return false;
+        LogMarker logMarker = (LogMarker) o;
+        return Objects.equals(name, logMarker.name)
+                && Objects.equals(references, logMarker.references);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, references);
     }
 }


### PR DESCRIPTION
By adding equals and hashcode methods to model classes, we can use the methods provided via the Collection-api, such as .contains(). If users has a need to handle model objects in Maps, such as HashMap, this is now also better supported.

Also renaming MarkerMapper to LogMarkerMapper for naming consistency.